### PR TITLE
Add hyperservice down command

### DIFF
--- a/apps/hyperservice/operations/service/down.sh
+++ b/apps/hyperservice/operations/service/down.sh
@@ -1,0 +1,33 @@
+# Function to handle the 'down' command
+service_down() {
+  local json_output
+  json_output=$(moon query projects --json)
+
+  echo "$json_output" | jq -c '.projects[]' | while read -r project; do
+    local name
+    local workdir
+    name=$(echo "$project" | jq -r '.id')
+    workdir=$(echo "$project" | jq -r '.source')
+
+    if [[ -f "$workdir/.hyperservice/dataplane.yml" ]]; then
+      hyperservice "$name" stop
+    fi
+  done
+}
+
+# Function to handle the 'down --clean' command
+service_down_clean() {
+  local json_output
+  json_output=$(moon query projects --json)
+
+  echo "$json_output" | jq -c '.projects[]' | while read -r project; do
+    local name
+    local workdir
+    name=$(echo "$project" | jq -r '.id')
+    workdir=$(echo "$project" | jq -r '.source')
+
+    if [[ -f "$workdir/.hyperservice/dataplane.yml" ]]; then
+      hyperservice "$name" clean
+    fi
+  done
+}


### PR DESCRIPTION
Fixes #14

Add logic to handle the `down` command and `--clean` option for stopping and cleaning all hyperservices.

* **apps/hyperservice/manage.sh**
  - Add logic to handle the `down` command.
  - Add logic to handle the `--clean` option for the `down` command.
  - Update usage information to include `down` and `down --clean` commands.
  - Validate the `--clean` option to ensure it is only used with the `down` command.

* **apps/hyperservice/operations/service/down.sh**
  - Add `service_down` function to stop all hyperservices.
  - Add `service_down_clean` function to clean all hyperservices.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tiagovinicius/hyper-services/pull/15?shareId=80bf57b0-a264-474d-a73c-450c40c954cf).