### PR TITLE
Add fleet simulation of a service

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/devcontainers-contrib/features/curl-apt-get:1": {},
     "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
-      "packages": "sudo"
+      "packages": "sudo,uuid-runtime,yq"
     }
   },
   "runArgs": ["--env-file", ".devcontainer/.env"],
@@ -15,6 +15,9 @@
   "containerEnv": {
     "WORKSPACE_FOLDER": "${containerWorkspaceFolder}"
   },
+  "mounts": [
+    "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+  ],
   // Configure tool-specific properties.
   "customizations": {
     "settings": {

--- a/apps/edge-gateway/.hyperservice/policies/traffic-permission-to-service-b.yml
+++ b/apps/edge-gateway/.hyperservice/policies/traffic-permission-to-service-b.yml
@@ -1,5 +1,5 @@
 type: MeshTrafficPermission
-name: service-b-allow-from-edge-gateway
+name: edge-gateway-allow-to-service-b
 mesh: default
 spec:
   targetRef:

--- a/apps/hyperservice/fleet-simulator/Dockerfile
+++ b/apps/hyperservice/fleet-simulator/Dockerfile
@@ -1,0 +1,5 @@
+FROM docker:dind
+
+RUN apk add --no-cache bash
+
+CMD ["/bin/bash", "-c", "sleep infinity"]

--- a/apps/hyperservice/fleet-simulator/build-image.sh
+++ b/apps/hyperservice/fleet-simulator/build-image.sh
@@ -1,0 +1,1 @@
+docker build -t hyperservice-fleet-simulator-image apps/hyperservice/fleet-simulator

--- a/apps/hyperservice/operations/mesh/up.sh
+++ b/apps/hyperservice/operations/mesh/up.sh
@@ -2,5 +2,6 @@
 mesh_up() {
     # Execute build-image.sh script
     bash modules/kuma/dataplane-deployment/build-image.sh
+    bash apps/hyperservice/fleet-simulator/build-image.sh
     docker-compose -f modules/kuma/control-plane-deployment/docker-compose.yml up
 } 

--- a/apps/hyperservice/operations/service/clean.sh
+++ b/apps/hyperservice/operations/service/clean.sh
@@ -12,13 +12,22 @@ service_clean() {
   fi
 
   # Stop the hyperservice if it is running
-  if docker ps -q --filter "name=$name" | grep -q .; then
+  if docker ps -q --filter "name=^$name(-.*|$)" | grep -q .; then
     echo "Stopping hyperservice: $name"
-    docker stop "$name"
+    docker ps -q --filter "name=^$name(-.*|$)" | while read -r container_id; do
+      echo "Stopping container: $container_id"
+      docker stop "$container_id"
+    done
   fi
-  
-  # Remove the hyperservice
-  docker rm "$name"
+
+  # Remove the hyperservice containers
+  if docker ps -a -q --filter "name=^$name(-.*|$)" | grep -q .; then
+    echo "Removing containers for hyperservice: $name"
+    docker ps -a -q --filter "name=^$name(-.*|$)" | while read -r container_id; do
+      echo "Removing container: $container_id"
+      docker rm "$container_id"
+    done
+  fi
 
   echo "Hyperservice $name cleaned successfully."
 }

--- a/apps/hyperservice/operations/service/restart.sh
+++ b/apps/hyperservice/operations/service/restart.sh
@@ -10,18 +10,44 @@ service_restart() {
     echo "Removing existing hyperservice: $NAME"
     docker rm -f "$NAME"
   fi
-  echo "Creating and starting hyperservice: $NAME"
-  docker run -d \
-    --name "$NAME" \
-    --volume "/workspace:/workspace" \
-    --volume "/etc/shared/environment:/etc/shared/environment" \
-    --workdir "/workspace/$WORKDIR" \
-    --env "KUMA_DPP=$NAME" \
-    --env "DATAPLANE_NAME=$NAME" \
-    --env "WORKSPACE_FOLDER=$WORKSPACE_FOLDER" \
-    --network service-mesh \
-    --privileged \
-    hyper-dataplane-image
+
+  if [[ -f "$workdir/.hyperservice/fleet.yml" ]]; then
+    echo "fleet.yml found. Creating multiple containers."
+    local units
+    units=$(yq e '.simulator.units' "$workdir/.hyperservice/fleet.yml")
+
+    for ((i = 1; i <= units; i++)); do
+      local container_name="${name}-$(uuidgen | cut -c1-8)"
+      echo "Creating and starting container: $container_name"
+      docker run -d \
+        --name "$container_name" \
+        --volume "/workspace:/workspace" \
+        --volume "/etc/shared/environment:/etc/shared/environment" \
+        --workdir "/workspace/$workdir" \
+        --env "KUMA_DPP=$container_name" \
+        --env "DATAPLANE_NAME=$container_name" \
+        --env "WORKSPACE_FOLDER=$WORKSPACE_FOLDER" \
+        --network service-mesh \
+        --privileged \
+        docker:latest
+
+      echo "Running docker run inside container: $container_name"
+      docker exec "$container_name" docker run -d --name "inner-$container_name" alpine:latest sleep 3600
+    done
+  else
+    echo "Creating and starting hyperservice: $NAME"
+    docker run -d \
+      --name "$NAME" \
+      --volume "/workspace:/workspace" \
+      --volume "/etc/shared/environment:/etc/shared/environment" \
+      --workdir "/workspace/$WORKDIR" \
+      --env "KUMA_DPP=$NAME" \
+      --env "DATAPLANE_NAME=$NAME" \
+      --env "WORKSPACE_FOLDER=$WORKSPACE_FOLDER" \
+      --network service-mesh \
+      --privileged \
+      hyper-dataplane-image
+  fi
 
   echo "Hyperservice $name restarted successfully."
 }

--- a/apps/hyperservice/operations/service/restart.sh
+++ b/apps/hyperservice/operations/service/restart.sh
@@ -12,27 +12,49 @@ service_restart() {
   fi
 
   if [[ -f "$workdir/.hyperservice/fleet.yml" ]]; then
-    echo "fleet.yml found. Creating multiple containers."
+    echo "fleet.yml found. Creating fleet simulation."
     local units
-    units=$(yq e '.simulator.units' "$workdir/.hyperservice/fleet.yml")
+    units=$(yq -r '.simulator.units' "$workdir/.hyperservice/fleet.yml")
 
     for ((i = 1; i <= units; i++)); do
-      local container_name="${name}-$(uuidgen | cut -c1-8)"
-      echo "Creating and starting container: $container_name"
+      local base_name="${name}-$(uuidgen | cut -c1-8)"
+      local node_name="${base_name}-node"
+      local hyperservice_name="${base_name}"
+      echo "Creating and starting fleet unit simulation: $node_name"
       docker run -d \
-        --name "$container_name" \
+        --name "$node_name" \
+        --volume "/var/run/docker.sock:/var/run/docker.sock" \
         --volume "/workspace:/workspace" \
         --volume "/etc/shared/environment:/etc/shared/environment" \
-        --workdir "/workspace/$workdir" \
-        --env "KUMA_DPP=$container_name" \
-        --env "DATAPLANE_NAME=$container_name" \
+        --env "KUMA_DPP=$hyperservice_name" \
+        --env "DATAPLANE_NAME=$hyperservice_name" \
         --env "WORKSPACE_FOLDER=$WORKSPACE_FOLDER" \
         --network service-mesh \
-        --privileged \
-        docker:latest
+        hyperservice-fleet-simulator-image
 
-      echo "Running docker run inside container: $container_name"
-      docker exec "$container_name" docker run -d --name "inner-$container_name" alpine:latest sleep 3600
+      echo "Accessing fleet unit simulation: $node_name"
+      wait_for_docker $node_name 60
+      if [[ $? -eq 0 ]]; then
+        echo "Fleet unit is ready. Running further commands..."
+        echo "Creating and starting hypeservice: $hyperservice_name"
+        docker exec $node_name \
+        docker run --privileged -d \
+          --name "$hyperservice_name" \
+          --volume "/var/run/docker.sock:/var/run/docker.sock" \
+          --volume "/workspace:/workspace" \
+          --volume "/etc/shared/environment:/etc/shared/environment" \
+          --workdir "/workspace/$workdir" \
+          --env "KUMA_DPP=$hyperservice_name" \
+          --env "DATAPLANE_NAME=$hyperservice_name" \
+          --env "SERVICE_NAME=$NAME" \
+          --env "WORKSPACE_FOLDER=$WORKSPACE_FOLDER" \
+          --network service-mesh \
+          --privileged \
+          hyperservice-dataplane-image
+      else
+        echo "Failed to connect to the fleet unit: $container_name"
+      fi
+
     done
   else
     echo "Creating and starting hyperservice: $NAME"
@@ -46,7 +68,7 @@ service_restart() {
       --env "WORKSPACE_FOLDER=$WORKSPACE_FOLDER" \
       --network service-mesh \
       --privileged \
-      hyper-dataplane-image
+      hyperservice-dataplane-image
   fi
 
   echo "Hyperservice $name restarted successfully."

--- a/apps/hyperservice/operations/service/start.sh
+++ b/apps/hyperservice/operations/service/start.sh
@@ -5,23 +5,48 @@ service_start() {
   local workdir="$2"
 
   echo "Starting hyperservice: $name"
-  
-  if hyperservice_exists; then
-    echo "Starting existing hyperservice: $NAME"
-    docker start "$NAME"
+
+  if [[ -f "$workdir/.hyperservice/fleet.yml" ]]; then
+    echo "fleet.yml found. Creating multiple containers."
+    local units
+    units=$(yq e '.simulator.units' "$workdir/.hyperservice/fleet.yml")
+
+    for ((i = 1; i <= units; i++)); do
+      local container_name="${name}-$(uuidgen | cut -c1-8)"
+      echo "Creating and starting container: $container_name"
+      docker run -d \
+        --name "$container_name" \
+        --volume "/workspace:/workspace" \
+        --volume "/etc/shared/environment:/etc/shared/environment" \
+        --workdir "/workspace/$workdir" \
+        --env "KUMA_DPP=$container_name" \
+        --env "DATAPLANE_NAME=$container_name" \
+        --env "WORKSPACE_FOLDER=$WORKSPACE_FOLDER" \
+        --network service-mesh \
+        --privileged \
+        docker:latest
+
+      echo "Running docker run inside container: $container_name"
+      docker exec "$container_name" docker run -d --name "inner-$container_name" alpine:latest sleep 3600
+    done
   else
-    echo "Creating and starting hyperservice: $NAME"
-    docker run -d \
-      --name "$NAME" \
-      --volume "/workspace:/workspace" \
-      --volume "/etc/shared/environment:/etc/shared/environment" \
-      --workdir "/workspace/$WORKDIR" \
-      --env "KUMA_DPP=$NAME" \
-      --env "DATAPLANE_NAME=$NAME" \
-      --env "WORKSPACE_FOLDER=$WORKSPACE_FOLDER" \
-      --network service-mesh \
-      --privileged \
-      hyper-dataplane-image
+    if hyperservice_exists; then
+      echo "Starting existing hyperservice: $NAME"
+      docker start "$NAME"
+    else
+      echo "Creating and starting hyperservice: $NAME"
+      docker run -d \
+        --name "$NAME" \
+        --volume "/workspace:/workspace" \
+        --volume "/etc/shared/environment:/etc/shared/environment" \
+        --workdir "/workspace/$WORKDIR" \
+        --env "KUMA_DPP=$NAME" \
+        --env "DATAPLANE_NAME=$NAME" \
+        --env "WORKSPACE_FOLDER=$WORKSPACE_FOLDER" \
+        --network service-mesh \
+        --privileged \
+        hyper-dataplane-image
+    fi
   fi
 
   echo "Hyperservice $name started successfully."

--- a/apps/hyperservice/operations/service/stop.sh
+++ b/apps/hyperservice/operations/service/stop.sh
@@ -6,11 +6,17 @@ service_stop() {
   echo "Stopping hyperservice: $name"
 
   if hyperservice_exists; then
-    docker stop "$NAME"
+    CONTAINERS=$(docker ps -q --filter "name=^$NAME(-.*|$)")
+    echo "$CONTAINERS" | while read -r container_id; do
+      echo "Stopping container: $container_id"
+      docker stop "$container_id"
+    done
   else
     echo "Error: Hyperservice '$NAME' does not exist."
     exit 1
   fi
+
+  CONTAINERS=$(docker ps -q --filter "name=^$NAME")
 
   echo "Hyperservice $name stopped successfully."
 }

--- a/apps/hyperservice/utils/wait_for_docker.sh
+++ b/apps/hyperservice/utils/wait_for_docker.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Function to wait for a Docker container to become available
+wait_for_docker() {
+  local container_name="$1"
+  local timeout="${2:-60}" # Default timeout is 60 seconds
+
+  # Ensure a container name is provided
+  if [[ -z "$container_name" ]]; then
+    echo "Error: Container name is required."
+    echo "Usage: wait_for_docker <container_name> [timeout]"
+    return 1
+  fi
+
+  echo "Waiting for container '$container_name' to become available..."
+
+  local elapsed=0
+
+  # Function to check if Docker is ready
+  is_docker_ready() {
+    docker exec "$container_name" echo "ready" >/dev/null 2>&1
+  }
+
+  # Loop to wait until Docker is ready
+  while ! is_docker_ready; do
+    sleep 1
+    elapsed=$((elapsed + 1))
+
+    if [[ "$elapsed" -ge "$timeout" ]]; then
+      echo "Error: Container '$container_name' did not become available within $timeout seconds."
+      return 1
+    fi
+  done
+
+  echo "Container '$container_name' is available. Proceeding..."
+  return 0
+}
+
+# Example usage of the function
+# Uncomment the lines below to test the function in a script:
+
+# wait_for_docker "my_container" 30
+# if [[ $? -eq 0 ]]; then
+#   echo "Container is ready. Running further commands..."
+# else
+#   echo "Failed to connect to the container."
+# fi

--- a/apps/service-b/.hyperservice/dataplane.yml
+++ b/apps/service-b/.hyperservice/dataplane.yml
@@ -1,12 +1,12 @@
 type: Dataplane
 mesh: default
-name: service-b
+name: $DATAPLANE_NAME
 networking:
   address: $CONTAINER_IP
   inbound:
     - port: 3002
       tags:
-        kuma.io/service: service-b
+        kuma.io/service: $DATAPLANE_NAME
   transparentProxying:
     redirectPortInbound: 15006
     redirectPortOutbound: 15001

--- a/apps/service-b/.hyperservice/fleet.yml
+++ b/apps/service-b/.hyperservice/fleet.yml
@@ -1,2 +1,2 @@
 simulator:
-  units: 3
+  units: 1

--- a/apps/service-b/.hyperservice/policies/traffic-permission-to-service-a.yml
+++ b/apps/service-b/.hyperservice/policies/traffic-permission-to-service-a.yml
@@ -1,5 +1,5 @@
 type: MeshTrafficPermission
-name: service-a-allow-from-service-b
+name: $DATAPLANE_NAME-allow-to-service-a
 mesh: default
 spec:
   targetRef:
@@ -10,6 +10,6 @@ spec:
     - targetRef:
         kind: MeshSubset
         tags:
-          kuma.io/service: service-b
+          kuma.io/service: $DATAPLANE_NAME
       default:
         action: Allow

--- a/modules/kuma/dataplane-deployment/build-image.sh
+++ b/modules/kuma/dataplane-deployment/build-image.sh
@@ -1,1 +1,1 @@
-docker build -t hyper-dataplane-image modules/kuma/dataplane-deployment
+docker build -t hyperservice-dataplane-image modules/kuma/dataplane-deployment

--- a/modules/kuma/dataplane-deployment/entrypoint.sh
+++ b/modules/kuma/dataplane-deployment/entrypoint.sh
@@ -52,6 +52,6 @@ runuser -u kuma-dp -- \
     --dataplane="$(envsubst < .hyperservice/dataplane.yml)" \
     2>&1 | tee logs/dataplane-logs.txt &
 
-echo "Starting service"
-moon $DATAPLANE_NAME:dev --log trace\
+echo "Starting service $SERVICE_NAME"
+moon $SERVICE_NAME:dev \
   2>&1 | tee logs/app-logs.txt


### PR DESCRIPTION
Fixes #20

Add fleet simulation for hyperservice start and restart commands.

* Modify `apps/hyperservice/operations/service/start.sh` to check for `fleet.yml` and create multiple containers based on the specified units.
* Modify `apps/hyperservice/operations/service/restart.sh` to check for `fleet.yml` and create multiple containers based on the specified units.
* Parse `fleet.yml` to get the number of units and create containers with unique names.
* Run `docker run` inside each created container to start an inner container.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tiagovinicius/hyperservice/pull/21?shareId=854b991a-39c7-4bef-9c93-3141ed73894f).